### PR TITLE
Support reading completions.json when loading the package from snapshot

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,6 +1,8 @@
 fs = require 'fs'
 path = require 'path'
 
+CLASSES = require('../completions.json')
+
 propertyPrefixPattern = /(?:^|\[|\(|,|=|:|\s)\s*(atom\.(?:[a-zA-Z]+\.?){0,2})$/
 
 module.exports =
@@ -53,13 +55,7 @@ module.exports =
 
   loadCompletions: ->
     @completions ?= {}
-
-    fs.readFile path.resolve(__dirname, '..', 'completions.json'), (error, content) =>
-      return if error?
-      @completions = {}
-      classes = JSON.parse(content)
-      @loadProperty('atom', 'AtomEnvironment', classes)
-      return
+    @loadProperty('atom', 'AtomEnvironment', CLASSES)
 
   getCompletions: (line) ->
     completions = []


### PR DESCRIPTION
Using __dirname inside the snapshot will return a relative path, which will cause this package to fail to load completions from `{packageRoot}/completions.json`. With this pull request we use the require system to load such file so that it can be snapshotted; doing so will fix the aforementioned error and will improve performance as well because we will save a file system call.